### PR TITLE
Update Applio integration

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,5 +10,5 @@ applio_tts_output_path = <path to save TTS output>
 applio_rvc_output_path = <path to save RVC output>
 filtered_chars = ,;.-!?*  # Add any additional characters to filter here
 
-[GRADIO_CLIENT]
+[APPLIO]
 url = http://127.0.0.1:6969/

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import configparser
 import ollama
 import speech_recognition as sr
 import whisper
-from gradio_client import Client
+import requests
 from pydub import AudioSegment
 import sounddevice as sd
 from scipy.io import wavfile
@@ -34,8 +34,8 @@ APPLIO_TTS_OUTPUT_PATH = config['DEFAULT']['applio_tts_output_path']
 APPLIO_RVC_OUTPUT_PATH = config['DEFAULT']['applio_rvc_output_path']
 FILTERED_CHARS = config['DEFAULT']['filtered_chars']
 
-# Initialize Gradio Client for Applio
-client = Client(config['GRADIO_CLIENT']['url'])
+# Base URL of the Applio service
+APPLIO_URL = config['APPLIO']['url']
 
 
 def time_wrapper(func):
@@ -96,40 +96,46 @@ def get_ollama_response(prompt, user_id, model=OLLAMA_MODEL, conversation_histor
 @time_wrapper
 def convert_text_to_speech(text, output_tts_path, output_rvc_path):
     """
-    Convert text to speech using Applio's TTS API.
+    Convert text to speech using Applio via an HTTP request.
     :param text: The text to convert to speech.
     :param output_tts_path: The path to save the TTS audio file.
     :param output_rvc_path: The path to save the RVC audio file.
     :return: The path to the RVC audio file.
     """
+    payload = {
+        "tts_text": text,
+        "tts_voice": APPLIO_TTS_VOICE,
+        "output_tts_path": output_tts_path,
+        "output_rvc_path": output_rvc_path,
+        "pth_path": APPLIO_PTH_PATH,
+        "index_path": APPLIO_INDEX_PATH,
+        "tts_rate": 0,
+        "pitch": 0,
+        "filter_radius": 3,
+        "index_rate": 0.75,
+        "volume_envelope": 1,
+        "protect": 0.5,
+        "hop_length": 128,
+        "f0_method": "rmvpe",
+        "split_audio": False,
+        "f0_autotune": False,
+        "clean_audio": True,
+        "clean_strength": 0.5,
+        "export_format": "WAV",
+        "upscale_audio": False,
+        "f0_file": None,
+        "embedder_model": "contentvec",
+        "embedder_model_custom": None,
+    }
     try:
-        response = client.predict(
-            tts_text=text,
-            tts_voice=APPLIO_TTS_VOICE,
-            output_tts_path=output_tts_path,
-            output_rvc_path=output_rvc_path,
-            pth_path=APPLIO_PTH_PATH,
-            index_path=APPLIO_INDEX_PATH,
-            tts_rate=0,
-            pitch=0,
-            filter_radius=3,
-            index_rate=0.75,
-            volume_envelope=1,
-            protect=0.5,
-            hop_length=128,
-            f0_method="rmvpe",
-            split_audio=False,
-            f0_autotune=False,
-            clean_audio=True,
-            clean_strength=0.5,
-            export_format="WAV",
-            upscale_audio=False,
-            f0_file=None,
-            embedder_model="contentvec",
-            embedder_model_custom=None,
-            api_name="/run_tts_script"
+        response = requests.post(
+            f"{APPLIO_URL.rstrip('/')}/run_tts_script",
+            json=payload,
+            headers={"Accept": "application/json"},
+            timeout=120,
         )
-        logging.info(f"Response: {response}")
+        response.raise_for_status()
+        logging.info(f"Response: {response.text}")
         return output_rvc_path
     except Exception as e:
         logging.error(f"Could not convert text to speech: {e}")

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-This project provides an interface between the Ollama model and Applio's text-to-speech (TTS) and voice conversion services. It converts user speech input into text, generates responses using Ollama, and then synthesizes and plays back the response using Applio.
+This project provides an interface between the Ollama model and Applio's text-to-speech (TTS) and voice conversion services. It converts user speech input into text, generates responses using Ollama, and then synthesizes and plays back the response using Applio. The newest Applio releases expose their functionality over plain HTTP with CORS enabled instead of the previous gradio API.
 
 ## Features
 
@@ -33,9 +33,9 @@ The required Python packages are listed in `requirements.txt`. To install them, 
 
 2. **Ollama**: Install and run the Ollama service according to the instructions on their website. Make sure it's accessible at the specified URL.
 
-3. **Applio**: Install and run the Applio service according to the instructions on their website. Ensure it is running locally on the specified port (default: `http://127.0.0.1:6969/`).
+3. **Applio**: Install and run the Applio service according to the instructions on their website. The latest version exposes an HTTP endpoint with CORS enabled. Ensure it is running locally on the specified port (default: `http://127.0.0.1:6969/`).
 
-4. **Configuration File**: Update the `config.ini` file with the appropriate paths and settings for your environment. 
+4. **Configuration File**: Update the `config.ini` file with the appropriate paths and settings for your environment. The Applio URL is specified under the `[APPLIO]` section.
 
    - `START_PROMPT`: Your initial prompt for the Ollama model.
    - `OLLAMA_MODEL`: The name of the Ollama model to use.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pydub~=0.25.1
 sounddevice~=0.4.6
 scipy~=1.11.3
 pyaudio~=0.2.14
+requests~=2.31.0


### PR DESCRIPTION
## Summary
- switch from `gradio_client` to HTTP requests for Applio
- document new CORS-based Applio usage
- tweak config keys
- require the `requests` package

## Testing
- `python -m py_compile main.py`
- `python -m py_compile short_term_memory.py`


------
https://chatgpt.com/codex/tasks/task_e_68865acd32e4832f8ba3ab959bad1a1a